### PR TITLE
feat(game): Add tests for checkLineRL

### DIFF
--- a/game/algorithm_jules003_test.go
+++ b/game/algorithm_jules003_test.go
@@ -1,0 +1,200 @@
+package sgc7game
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_CheckLineRL_Jules(t *testing.T) {
+	// Symbol 0 is wild
+	// Symbol -1 is invalid
+	isWild := func(cursymbol int) bool {
+		return cursymbol == 0
+	}
+
+	isValidSymbol := func(cursymbol int) bool {
+		return cursymbol >= 0
+	}
+
+	isSameSymbol := func(cursymbol int, startsymbol int) bool {
+		return cursymbol == startsymbol || cursymbol == 0
+	}
+
+	getSymbol := func(cursymbol int) int {
+		return cursymbol
+	}
+
+	type testCase struct {
+		name          string
+		scene         *GameScene
+		line          []int
+		minnum        int
+		expectedWin   bool
+		expectedSym   int
+		expectedNums  int
+		expectedWilds int
+		expectedPos   []int
+	}
+
+	testCases := []testCase{
+		{
+			name: "Simple win, no wilds",
+			scene: &GameScene{
+				Arr: [][]int{
+					{1, 2, 3},
+					{4, 5, 6},
+					{7, 1, 1},
+					{8, 1, 2},
+					{9, 1, 3},
+				},
+			},
+			line:          []int{0, 0, 1, 1, 1},
+			minnum:        3,
+			expectedWin:   true,
+			expectedSym:   1,
+			expectedNums:  3,
+			expectedWilds: 0,
+			expectedPos:   []int{4, 1, 3, 1, 2, 1},
+		},
+		{
+			name: "No win, not enough symbols",
+			scene: &GameScene{
+				Arr: [][]int{
+					{1, 2, 3},
+					{4, 5, 6},
+					{7, 8, 1},
+					{9, 1, 2},
+					{9, 3, 3},
+				},
+			},
+			line:        []int{0, 0, 1, 1, 1},
+			minnum:      3,
+			expectedWin: false,
+		},
+		{
+			name: "Win with wilds",
+			scene: &GameScene{
+				Arr: [][]int{
+					{1, 2, 3},
+					{4, 5, 6},
+					{7, 0, 1}, // wild
+					{8, 1, 2},
+					{9, 1, 3},
+				},
+			},
+			line:          []int{0, 0, 1, 1, 1},
+			minnum:        3,
+			expectedWin:   true,
+			expectedSym:   1,
+			expectedNums:  3,
+			expectedWilds: 1,
+			expectedPos:   []int{4, 1, 3, 1, 2, 1},
+		},
+		{
+			name: "Win starts with wild (from right)",
+			scene: &GameScene{
+				Arr: [][]int{
+					{1, 2, 3},
+					{4, 5, 6},
+					{7, 1, 1},
+					{8, 1, 2},
+					{9, 0, 3}, // wild
+				},
+			},
+			line:          []int{0, 0, 1, 1, 1},
+			minnum:        3,
+			expectedWin:   true,
+			expectedSym:   1,
+			expectedNums:  3,
+			expectedWilds: 1,
+			expectedPos:   []int{4, 1, 3, 1, 2, 1},
+		},
+		{
+			name: "Win all wilds",
+			scene: &GameScene{
+				Arr: [][]int{
+					{1, 2, 3},
+					{-1, -1, -1}, // Use invalid symbols to ensure the line breaks after wilds
+					{7, 0, 1},    // Wild
+					{8, 0, 2},    // Wild
+					{9, 0, 3},    // Wild
+				},
+			},
+			line:          []int{0, 0, 1, 1, 1},
+			minnum:        3,
+			expectedWin:   true,
+			expectedSym:   0, // wild symbol
+			expectedNums:  3,
+			expectedWilds: 3,
+			expectedPos:   []int{4, 1, 3, 1, 2, 1},
+		},
+		{
+			name: "Special case: Wilds at start, non-wild determines symbol",
+			// C B W W W -> reading from right: W W W B C
+			scene: &GameScene{
+				Arr: [][]int{
+					{5, 2, 3}, // C
+					{4, 2, 6}, // B
+					{7, 0, 1}, // W
+					{8, 0, 2}, // W
+					{9, 0, 3}, // W
+				},
+			},
+			line:          []int{0, 1, 1, 1, 1},
+			minnum:        4,
+			expectedWin:   true,
+			expectedSym:   2, // Should be symbol B
+			expectedNums:  4,
+			expectedWilds: 3,
+			expectedPos:   []int{4, 1, 3, 1, 2, 1, 1, 1},
+		},
+		{
+			name: "Invalid start symbol",
+			scene: &GameScene{
+				Arr: [][]int{
+					{1, 2, 3},
+					{4, 5, 6},
+					{7, 1, 1},
+					{8, 1, 2},
+					{9, -1, 3}, // invalid
+				},
+			},
+			line:        []int{0, 0, 1, 1, 1},
+			minnum:      3,
+			expectedWin: false,
+		},
+		{
+			name: "Line broken by non-matching symbol",
+			scene: &GameScene{
+				Arr: [][]int{
+					{1, 2, 3},
+					{4, 5, 6},
+					{7, 8, 1}, // non-matching
+					{9, 1, 2},
+					{9, 1, 3},
+				},
+			},
+			line:        []int{0, 0, 1, 1, 1},
+			minnum:      3,
+			expectedWin: false, // Only 2 symbols match from right
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := CheckLineRL(tc.scene, tc.line, tc.minnum, isValidSymbol, isWild, isSameSymbol, getSymbol)
+
+			if !tc.expectedWin {
+				assert.Nil(t, result, "Expected no win, but got one")
+				return
+			}
+
+			assert.NotNil(t, result, "Expected a win, but got none")
+			assert.Equal(t, tc.expectedSym, result.Symbol, "Winning symbol mismatch")
+			assert.Equal(t, tc.expectedNums, result.SymbolNums, "Symbol count mismatch")
+			assert.Equal(t, tc.expectedWilds, result.Wilds, "Wild count mismatch")
+			assert.Equal(t, tc.expectedPos, result.Pos, "Positions mismatch")
+		})
+	}
+}

--- a/jules/plan-003-report.md
+++ b/jules/plan-003-report.md
@@ -1,0 +1,32 @@
+# Task Report: `checkLineRL` Test Coverage
+
+## Objective
+
+The primary goal of this task was to increase the test coverage for the `checkLineRL` function in `game/algorithm.go` to over 90%. This involved creating a new test file, `game/algorithm_jules003_test.go`, and implementing a comprehensive suite of test cases.
+
+## Work Performed
+
+1.  **Code Analysis**: I began by analyzing the `checkLineRL` function in `game/algorithm.go` to understand its logic, which processes game lines from right to left. I paid special attention to the handling of wild symbols, as this was identified as the most complex part of the function.
+
+2.  **Test File Creation**: I created a new test file, `game/algorithm_jules003_test.go`, to house the new tests.
+
+3.  **Test Case Development**: I designed and implemented a table-driven test suite (`Test_CheckLineRL_Jules`) with a variety of scenarios to ensure thorough testing:
+    *   Simple winning lines without wild symbols.
+    *   Scenarios where no win occurs.
+    *   Winning lines that include wild symbols.
+    *   Lines where the winning combination starts with a wild symbol (from the right).
+    *   Lines composed entirely of wild symbols.
+    *   The specific edge case where a line starts with wilds, and the first non-wild symbol determines the winning symbol.
+    *   Cases involving invalid symbols or line-breaking symbols.
+
+4.  **Debugging**: During initial test runs, a failure was identified in the "Win all wilds" test case. The issue was traced to incorrect test data that didn't accurately reflect the intended scenario. I corrected the test data to properly isolate the all-wilds line, ensuring the chain of symbols was broken correctly by an invalid symbol.
+
+5.  **Coverage Verification**: After fixing the test and confirming that all tests passed, I ran Go's coverage tool. The results showed that the test coverage for the `checkLineRL` function is now **94.5%**.
+
+## Results
+
+*   **Test Coverage**: The test coverage for `checkLineRL` was successfully increased to **94.5%**, exceeding the 90% target.
+*   **New Test File**: A new test file, `game/algorithm_jules003_test.go`, has been added to the codebase with robust tests for the `checkLineRL` function.
+*   **Bugs Fixed**: A flaw in the new test suite was identified and corrected.
+
+The task is now complete. The `checkLineRL` function is well-tested, ensuring its reliability and correctness.


### PR DESCRIPTION
Adds a new test file `game/algorithm_jules003_test.go` with a comprehensive test suite for the `checkLineRL` function.

The new tests cover various scenarios, including:
- Simple wins
- No wins
- Wins with wilds
- Wins starting with wilds (from the right)
- All-wild wins
- The special case where wilds are followed by a non-wild that determines the symbol
- Invalid starting symbols

This increases the test coverage for `checkLineRL` to 94.5%, satisfying the task's requirement of over 90%.

A report detailing the work has been created at `jules/plan-003-report.md`.