### PR TITLE
feat(game): add comprehensive tests for valmapping2.go

### DIFF
--- a/game/valmapping2_jules_test.go
+++ b/game/valmapping2_jules_test.go
@@ -1,0 +1,99 @@
+package sgc7game
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValMapping2_IsEmpty_jules(t *testing.T) {
+	vm1, err := NewValMapping2([]int{1}, []IVal{NewIntValEx[int](10)})
+	assert.NoError(t, err)
+	assert.NotNil(t, vm1)
+	assert.False(t, vm1.IsEmpty())
+
+	vm2 := NewValMappingEx2()
+	assert.NotNil(t, vm2)
+	assert.True(t, vm2.IsEmpty())
+
+	t.Logf("Test_ValMapping2_IsEmpty_jules OK")
+}
+
+func Test_ValMapping2_Keys_jules(t *testing.T) {
+	vm1, err := NewValMapping2([]int{1, 2, 3}, []IVal{NewIntValEx[int](10), NewIntValEx[int](20), NewIntValEx[int](30)})
+	assert.NoError(t, err)
+	assert.NotNil(t, vm1)
+
+	keys := vm1.Keys()
+	sort.Ints(keys)
+	assert.Equal(t, []int{1, 2, 3}, keys)
+
+	vm2 := NewValMappingEx2()
+	assert.NotNil(t, vm2)
+	assert.Empty(t, vm2.Keys())
+
+	t.Logf("Test_ValMapping2_Keys_jules OK")
+}
+
+func Test_ValMapping2_Clone_jules(t *testing.T) {
+	vm1, err := NewValMapping2([]int{1}, []IVal{NewIntValEx[int](10)})
+	assert.NoError(t, err)
+	assert.NotNil(t, vm1)
+
+	vm2 := vm1.Clone()
+	assert.NotNil(t, vm2)
+	assert.NotSame(t, vm1, vm2)
+	assert.Equal(t, vm1.MapVals[1], vm2.MapVals[1])
+
+	// As IVal is an interface, the values are pointers, so they are the same.
+	// This is the expected behavior of Clone.
+	// If a deep copy of IVal is needed, it should be done outside.
+	assert.Same(t, vm1.MapVals[1], vm2.MapVals[1])
+
+	vm1.MapVals[1] = NewIntValEx[int](20)
+	assert.NotEqual(t, vm1.MapVals[1], vm2.MapVals[1])
+
+	t.Logf("Test_ValMapping2_Clone_jules OK")
+}
+
+func Test_NewValMapping2_jules(t *testing.T) {
+	vm1, err := NewValMapping2([]int{1, 2}, []IVal{NewIntValEx[int](10), NewIntValEx[int](20)})
+	assert.NoError(t, err)
+	assert.NotNil(t, vm1)
+	assert.Equal(t, 2, len(vm1.MapVals))
+	assert.Equal(t, int64(10), vm1.MapVals[1].Int64())
+	assert.Equal(t, int64(20), vm1.MapVals[2].Int64())
+
+	vm2, err := NewValMapping2([]int{1}, []IVal{NewIntValEx[int](10), NewIntValEx[int](20)})
+	assert.Error(t, err)
+	assert.Nil(t, vm2)
+	assert.Equal(t, ErrInvalidValMapping, err)
+
+	t.Logf("Test_NewValMapping2_jules OK")
+}
+
+func Test_NewValMappingEx2_jules(t *testing.T) {
+	vm := NewValMappingEx2()
+	assert.NotNil(t, vm)
+	assert.NotNil(t, vm.MapVals)
+	assert.Empty(t, vm.MapVals)
+
+	t.Logf("Test_NewValMappingEx2_jules OK")
+}
+
+func Test_LoadValMapping2FromExcel_jules_nonexistent(t *testing.T) {
+	vam, err := LoadValMapping2FromExcel("./testdata/nonexistent.xlsx", "index", "values", NewIntArrVal[int])
+	assert.Error(t, err)
+	assert.Nil(t, vam)
+
+	t.Logf("Test_LoadValMapping2FromExcel_jules_nonexistent OK")
+}
+
+func Test_LoadValMapping2FromExcel_jules_invalid(t *testing.T) {
+	vam, err := LoadValMapping2FromExcel("./testdata/valmapping_invalid.xlsx", "type", "val", NewIntVal[int])
+	assert.Error(t, err)
+	assert.Nil(t, vam)
+
+	t.Logf("Test_LoadValMapping2FromExcel_jules_invalid OK")
+}

--- a/jules/plan-013-report.md
+++ b/jules/plan-013-report.md
@@ -1,0 +1,37 @@
+# Task Report: plan-013
+
+## Summary
+
+In this task, I was asked to add test cases for files in the `game` directory, with the goal of achieving over 90% test coverage for the selected files.
+
+After analyzing the directory and excluding files as requested, I identified `game/valmapping2.go` as the primary candidate for new tests.
+
+## Work Done
+
+1.  **File Analysis**: I listed all `.go` files in the `game` directory, filtered out the excluded files and those that already had comprehensive tests written by "jules". `valmapping2.go` was the only remaining file with significant logic that was not fully tested.
+
+2.  **Test Implementation**: I created a new test file, `game/valmapping2_jules_test.go`, to house the new tests. I implemented test cases for the following functions, which were previously uncovered:
+    *   `IsEmpty()`
+    *   `Keys()`
+    *   `Clone()`
+    *   `NewValMapping2()`
+    *   `NewValMappingEx2()`
+
+3.  **Enhanced Error Handling Tests**: I enhanced the tests for the `LoadValMapping2FromExcel` function by adding test cases for error conditions:
+    *   Loading a non-existent Excel file.
+    *   Loading an Excel file with malformed data.
+
+4.  **Coverage Verification**: After implementing the tests, I ran the test suite and verified the code coverage for `game/valmapping2.go`. The final coverage for the file is above 90%, meeting the task's requirement.
+
+    ```
+    github.com/zhs007/slotsgamecore7/game/valmapping2.go:15:	IsEmpty					100.0%
+    github.com/zhs007/slotsgamecore7/game/valmapping2.go:19:	Keys					100.0%
+    github.com/zhs007/slotsgamecore7/game/valmapping2.go:29:	Clone					100.0%
+    github.com/zhs007/slotsgamecore7/game/valmapping2.go:41:	NewValMapping2				100.0%
+    github.com/zhs007/slotsgamecore7/game/valmapping2.go:62:	NewValMappingEx2			100.0%
+    github.com/zhs007/slotsgamecore7/game/valmapping2.go:69:	LoadValMapping2FromExcel		90.9%
+    ```
+
+## Conclusion
+
+I have successfully added comprehensive tests for `game/valmapping2.go`, significantly improving its test coverage and ensuring its reliability. All new tests are passing.


### PR DESCRIPTION
This change introduces a new test file `game/valmapping2_jules_test.go` to increase the test coverage of `game/valmapping2.go`.

The new tests cover the following functions:
- `IsEmpty`
- `Keys`
- `Clone`
- `NewValMapping2`
- `NewValMappingEx2`

Additionally, it adds error-handling test cases for `LoadValMapping2FromExcel`, including scenarios with non-existent or malformed Excel files.

This effort successfully increased the test coverage for `valmapping2.go` to over 90%.

A report detailing the work has been added in `jules/plan-013-report.md`.